### PR TITLE
Use responsive layout for blocks with alignwide class

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1276,8 +1276,9 @@ function amp_get_content_sanitizers( $post = null ) {
 		'AMP_Audio_Sanitizer'             => [],
 		'AMP_Playbuzz_Sanitizer'          => [],
 		'AMP_Iframe_Sanitizer'            => [
-			'add_placeholder' => true,
-			'current_origin'  => $current_origin,
+			'add_placeholder'    => true,
+			'current_origin'     => $current_origin,
+			'align_wide_support' => current_theme_supports( 'align-wide' ),
 		],
 		'AMP_Gallery_Block_Sanitizer'     => [ // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
 			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -140,8 +140,11 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 					$figure_node_classes = explode( ' ', $figure_node->getAttribute( 'class' ) );
 
-					// Changes layout to responsive for videos which have wide or full width (contains alignwide or alignfull class).
-					$show_responsive = ( in_array( 'alignfull', $figure_node_classes, true ) || in_array( 'alignwide', $figure_node_classes, true ) );
+					// If the alignment was set to 'wide width' or 'full width', set the layout to responsive.
+					$show_responsive = (
+						in_array( 'alignfull', $figure_node_classes, true ) ||
+						in_array( 'alignwide', $figure_node_classes, true )
+					);
 
 					if ( true === $show_responsive ) {
 						$normalized_attributes['layout'] = 'responsive';

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -6,6 +6,8 @@
  */
 
 use AmpProject\DevMode;
+use AmpProject\Attribute;
+use AmpProject\Layout;
 
 /**
  * Class AMP_Iframe_Sanitizer
@@ -124,8 +126,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			$this->did_convert_elements = true;
-			if ( empty( $normalized_attributes['layout'] ) && ! empty( $normalized_attributes['width'] ) && ! empty( $normalized_attributes['height'] ) ) {
-				$normalized_attributes['layout'] = 'intrinsic';
+			if ( empty( $normalized_attributes[ Attribute::LAYOUT ] ) && ! empty( $normalized_attributes[ Attribute::HEIGHT ] ) && ! empty( $normalized_attributes[ Attribute::WIDTH ] ) ) {
 
 				// Set layout to responsive if the iframe is aligned to full width.
 				$figure_node = null;
@@ -136,14 +137,14 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					$figure_node = $node->parentNode->parentNode;
 				}
 
-				if ( $figure_node && $figure_node->hasAttribute( 'class' ) ) {
-
-					$figure_node_classes = preg_split( '/\s+/', trim( $figure_node->getAttribute( 'class' ) ) );
-
-					// If the alignment was set to 'wide width' or 'full width', set the layout to responsive.
-					if ( in_array( 'alignfull', $figure_node_classes, true ) || in_array( 'alignwide', $figure_node_classes, true ) ) {
-						$normalized_attributes['layout'] = 'responsive';
-					}
+				if (
+					! empty( $this->args['align_wide_support'] )
+					&& $figure_node
+					&& preg_match( '/(^|\s)(alignwide|alignfull)(\s|$)/', $figure_node->getAttribute( Attribute::CLASS_ ) )
+				) {
+					$normalized_attributes[ Attribute::LAYOUT ] = Layout::RESPONSIVE;
+				} else {
+					$normalized_attributes[ Attribute::LAYOUT ] = Layout::INTRINSIC;
 				}
 
 				$this->add_or_append_attribute( $normalized_attributes, 'class', 'amp-wp-enforced-sizes' );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -138,15 +138,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 				if ( $figure_node && $figure_node->hasAttribute( 'class' ) ) {
 
-					$figure_node_classes = explode( ' ', $figure_node->getAttribute( 'class' ) );
+					$figure_node_classes = preg_split( '/\s+/', trim( $figure_node->getAttribute( 'class' ) ) );
 
 					// If the alignment was set to 'wide width' or 'full width', set the layout to responsive.
-					$show_responsive = (
-						in_array( 'alignfull', $figure_node_classes, true ) ||
-						in_array( 'alignwide', $figure_node_classes, true )
-					);
-
-					if ( true === $show_responsive ) {
+					if ( in_array( 'alignfull', $figure_node_classes, true ) || in_array( 'alignwide', $figure_node_classes, true ) ) {
 						$normalized_attributes['layout'] = 'responsive';
 					}
 				}

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -140,6 +140,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 					$figure_node_classes = explode( ' ', $figure_node->getAttribute( 'class' ) );
 
+					// Changes layout to responsive for videos which have wide or full width (contains alignwide or alignfull class).
 					$show_responsive = ( in_array( 'alignfull', $figure_node_classes, true ) || in_array( 'alignwide', $figure_node_classes, true ) );
 
 					if ( true === $show_responsive ) {

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -135,8 +135,16 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				if ( $node->parentNode->parentNode instanceof DOMElement && 'figure' === $node->parentNode->parentNode->tagName ) {
 					$figure_node = $node->parentNode->parentNode;
 				}
-				if ( $figure_node && $figure_node->hasAttribute( 'class' ) && in_array( 'alignfull', explode( ' ', $figure_node->getAttribute( 'class' ) ), true ) ) {
-					$normalized_attributes['layout'] = 'responsive';
+
+				if ( $figure_node && $figure_node->hasAttribute( 'class' ) ) {
+
+					$figure_node_classes = explode( ' ', $figure_node->getAttribute( 'class' ) );
+
+					$show_responsive = ( in_array( 'alignfull', $figure_node_classes, true ) || in_array( 'alignwide', $figure_node_classes, true ) );
+
+					if ( true === $show_responsive ) {
+						$normalized_attributes['layout'] = 'responsive';
+					}
 				}
 
 				$this->add_or_append_attribute( $normalized_attributes, 'class', 'amp-wp-enforced-sizes' );

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -405,6 +405,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				[
 					'add_noscript_fallback' => true,
 					'add_placeholder'       => true,
+					'align_wide_support'    => true,
 				],
 			],
 
@@ -423,6 +424,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				[
 					'add_noscript_fallback' => true,
 					'add_placeholder'       => true,
+					'align_wide_support'    => true,
 				],
 			],
 

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -408,6 +408,24 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'iframe_with_wide_width_alignment'               => [
+				'<figure class="alignwide"><iframe width="750" height="422" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0" allowfullscreen="" data-origwidth="750" data-origheight="422"></iframe></figure>',
+				'
+					<figure class="alignwide">
+						<amp-iframe width="750" height="422" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0" allowfullscreen="" data-origwidth="750" data-origheight="422" sandbox="allow-scripts allow-same-origin" layout="responsive" class="amp-wp-enforced-sizes">
+							<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+							<noscript>
+								<iframe width="750" height="422" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0"></iframe>
+							</noscript>
+						</amp-iframe>
+					</figure>
+				',
+				[
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				],
+			],
+
 			'test_with_dev_mode' => [
 				'<iframe data-ampdevmode="" src="about:blank" onload="alert(\'Hey.\')"></iframe>',
 				null, // No change.


### PR DESCRIPTION
## Summary
- Use the responsive layout for blocks with align wide class

Addresses issue #4692 

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
